### PR TITLE
Add social links and typing effect

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,15 +2,72 @@
 title: Paulo Correia's Journal
 ---
 
-# Boas-vindas ao bloco de notas de Paulo Correia
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 
-Neste espaço registro minhas atividades, pensamentos e desenvolvimento pessoal. 
+<style>
+  .social-links {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+  }
+  .social-links a {
+    margin-left: 10px;
+    font-size: 1.5rem;
+    color: inherit;
+  }
+  .intro {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 80vh;
+    font-size: 2rem;
+    font-weight: bold;
+  }
+</style>
 
-Este é um portifólio profissional. 
+<div class="social-links">
+  <a href="https://www.instagram.com/pcorreia.it" target="_blank" rel="noopener" aria-label="Instagram">
+    <i class="fab fa-instagram"></i>
+  </a>
+  <a href="https://github.com/pcorreia-it" target="_blank" rel="noopener" aria-label="GitHub">
+    <i class="fab fa-github"></i>
+  </a>
+</div>
 
-Conheça mais sobre:
+<div class="intro">
+  Paulo <span id="typed"></span>
+</div>
 
-# projetos
-# Localidades
-# Eventos
-# Pessoas
+<script>
+document.addEventListener("DOMContentLoaded", () => {
+  const words = ["é pai.", "é engenheiro.", "é marido.", "é brasileiro.", "é italiano.", "é músico."]; 
+  let wordIndex = 0;
+  let charIndex = 0;
+  const typed = document.getElementById("typed");
+
+  function type() {
+    const word = words[wordIndex];
+    if (charIndex <= word.length) {
+      typed.textContent = word.slice(0, charIndex);
+      charIndex++;
+      setTimeout(type, 150);
+    } else {
+      setTimeout(erase, 1000);
+    }
+  }
+
+  function erase() {
+    const word = words[wordIndex];
+    if (charIndex >= 0) {
+      typed.textContent = word.slice(0, charIndex);
+      charIndex--;
+      setTimeout(erase, 100);
+    } else {
+      wordIndex = (wordIndex + 1) % words.length;
+      setTimeout(type, 500);
+    }
+  }
+
+  type();
+});
+</script>


### PR DESCRIPTION
## Summary
- update the homepage
  - add Instagram and GitHub links with icons in the corner
  - show minimal text with typing animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68416f71a7748320b1f54f57f36351f9