### PR TITLE
Fix typing loop resetting char index

### DIFF
--- a/index.md
+++ b/index.md
@@ -84,6 +84,7 @@ document.addEventListener("DOMContentLoaded", () => {
       setTimeout(erase, 100);
     } else {
       wordIndex = (wordIndex + 1) % words.length;
+      charIndex = 0;
       setTimeout(type, 500);
     }
   }


### PR DESCRIPTION
## Summary
- ensure typing animation restarts correctly

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d7273f28832097ff2fd614327750